### PR TITLE
IA-716 Add maven setup steps for local deployment

### DIFF
--- a/DeveloperDocumentation/Deployment/deployment-local.md
+++ b/DeveloperDocumentation/Deployment/deployment-local.md
@@ -71,6 +71,11 @@ and some details about that user should be shown.
     ```shell
     cd .m2
     ```
+   If the directory does not exist, create it
+    
+    ```shell
+   mkdir .m2
+   ```
 
 3. Copy the xml code block from
 [this document](https://github.com/National-Digital-Twin/federator/blob/main/docs/running-locally.md#maven-setup):

--- a/DeveloperDocumentation/Deployment/deployment-local.md
+++ b/DeveloperDocumentation/Deployment/deployment-local.md
@@ -62,7 +62,7 @@ curl -H "Authorization: bearer <id token>" http://localhost:8091/whoami
 and some details about that user should be shown.
 
 ### Prepare authentication for fetching GitHub packages
-1. Navigate to the root directory of your machine, then do the following:
+1. Navigate to the home directory of your machine, then do the following:
     ```shell
     ls -a
     ```
@@ -72,8 +72,44 @@ and some details about that user should be shown.
     cd .m2
     ```
 
-3. Go to [this document](https://github.com/National-Digital-Twin/federator/blob/main/docs/running-locally.md#maven-setup)
-   and copy the xml code block
+3. Copy the xml code block from
+[this document](https://github.com/National-Digital-Twin/federator/blob/main/docs/running-locally.md#maven-setup):
+    
+    ```xml
+     <settings>
+         <activeProfiles>
+             <activeProfile>github</activeProfile>
+         </activeProfiles>
+    
+         <!--  Optional as this will also be defined in the pom file  -->
+         <profiles>
+             <profile>
+                 <id>github</id>
+                 <repositories>
+                     <repository>
+                         <id>central</id>
+                         <url>https://repo1.maven.org/maven2</url>
+                     </repository>
+                     <repository>
+                         <id>github</id>
+                         <url>https://maven.pkg.github.com/National-Digital-Twin/*</url>
+                         <snapshots>
+                             <enabled>true</enabled>
+                         </snapshots>
+                     </repository>
+                 </repositories>
+             </profile>
+         </profiles>
+    
+         <servers>
+             <server>
+                 <id>github</id>
+                 <username>YOUR_GITHUB_USERNAME</username>
+                 <password>YOUR_TOKEN</password>
+             </server>
+         </servers>
+     </settings>
+     ```
 
 4. Create a `settings.xml` file and paste the code block into it
 

--- a/DeveloperDocumentation/Deployment/deployment-local.md
+++ b/DeveloperDocumentation/Deployment/deployment-local.md
@@ -62,7 +62,49 @@ curl -H "Authorization: bearer <id token>" http://localhost:8091/whoami
 and some details about that user should be shown.
 
 ### Prepare authentication for fetching GitHub packages
-https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-to-github-packages
+Currently, we are using GitHub package repositories to distribute libraries. To ensure that Maven has access to the package repositories we need to update the settings.
+Instructions on how to do this can be found [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry) which will contain additional information.
+
+You will need to generate a [personal access token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-with-a-personal-access-token) that has at least has access to reading package registries.
+Open up `$MAVEN_HOME/.m2/settings.xml` and add the following, replacing the GitHub username and PAT with your own.
+
+```xml
+<settings>
+    <activeProfiles>
+        <activeProfile>github</activeProfile>
+    </activeProfiles>
+
+    <!--  Optional as this will also be defined in the pom file  -->
+    <profiles>
+        <profile>
+            <id>github</id>
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <url>https://repo1.maven.org/maven2</url>
+                </repository>
+                <repository>
+                    <id>github</id>
+                    <url>https://maven.pkg.github.com/National-Digital-Twin/*</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+
+    <servers>
+        <server>
+            <id>github</id>
+            <username>YOUR_GITHUB_USERNAME</username>
+            <password>YOUR_TOKEN</password>
+        </server>
+    </servers>
+</settings>
+```
+
+If you have trouble finding your `.m2` folder, do `ls -a` in your root directory (Linux & Mac). You may need to create the `settings.xml` file if it doesn't already exist.
 
 ### Fetch source code and build packages
 ```

--- a/DeveloperDocumentation/Deployment/deployment-local.md
+++ b/DeveloperDocumentation/Deployment/deployment-local.md
@@ -62,49 +62,24 @@ curl -H "Authorization: bearer <id token>" http://localhost:8091/whoami
 and some details about that user should be shown.
 
 ### Prepare authentication for fetching GitHub packages
-Currently, we are using GitHub package repositories to distribute libraries. To ensure that Maven has access to the package repositories we need to update the settings.
-Instructions on how to do this can be found [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry) which will contain additional information.
+1. Navigate to the root directory of your machine, then do the following:
+    ```shell
+    ls -a
+    ```
 
-You will need to generate a [personal access token](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-with-a-personal-access-token) that has at least has access to reading package registries.
-Open up `$MAVEN_HOME/.m2/settings.xml` and add the following, replacing the GitHub username and PAT with your own.
+2. You should see a .m2 directory. Navigate to it
+    ```shell
+    cd .m2
+    ```
 
-```xml
-<settings>
-    <activeProfiles>
-        <activeProfile>github</activeProfile>
-    </activeProfiles>
+3. Go to [this document](https://github.com/National-Digital-Twin/federator/blob/main/docs/running-locally.md#maven-setup)
+   and copy the xml code block
 
-    <!--  Optional as this will also be defined in the pom file  -->
-    <profiles>
-        <profile>
-            <id>github</id>
-            <repositories>
-                <repository>
-                    <id>central</id>
-                    <url>https://repo1.maven.org/maven2</url>
-                </repository>
-                <repository>
-                    <id>github</id>
-                    <url>https://maven.pkg.github.com/National-Digital-Twin/*</url>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
+4. Create a `settings.xml` file and paste the code block into it
 
-    <servers>
-        <server>
-            <id>github</id>
-            <username>YOUR_GITHUB_USERNAME</username>
-            <password>YOUR_TOKEN</password>
-        </server>
-    </servers>
-</settings>
-```
+5. Replace `YOUR_GITHUB_USERNAME` and `YOUR_GITHUB_TOKEN` with your own credentials
 
-If you have trouble finding your `.m2` folder, do `ls -a` in your root directory (Linux & Mac). You may need to create the `settings.xml` file if it doesn't already exist.
+6. Save the file and exit
 
 ### Fetch source code and build packages
 ```


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

During installation multiple devs got stuck on setting up a PAT token and adding it to the `settings.xml` file. In order to make things clearer, we are going to update the docs with concise instructions.

## Description

The documentation has been updated with clearer steps on updating the `settings.xml` file and adding their credentials, including how to locate their `.m2` directory, as per ticket description.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
