### PR TITLE
IA-718 - Add correct instructions for fuseki-yaml-config setup

### DIFF
--- a/DeveloperDocumentation/Deployment/deployment-local.md
+++ b/DeveloperDocumentation/Deployment/deployment-local.md
@@ -65,31 +65,63 @@ and some details about that user should be shown.
 https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-to-github-packages
 
 ### Fetch source code and build packages
+
+#### rdf-abac
 ```
 git clone https://github.com/National-Digital-Twin/rdf-abac
 cd rdf-abac
 mvn clean install
 cd ..
+```
+
+#### jwt-servlet-auth
+
+```
 git clone https://github.com/National-Digital-Twin/jwt-servlet-auth
 cd jwt-servlet-auth
 mvn clean install
+cd ..
+```
+
+#### secure-agents-lib
+```
 git clone https://github.com/National-Digital-Twin/secure-agents-lib.git
 cd secure-agents-lib
 (Ensure Docker is running as the tests use it)
 mvn clean install
 cd ..
+```
+
+#### jena-fuseki-kafka
+```
 git clone https://github.com/National-Digital-Twin/jena-fuseki-kafka
 cd jena-fuseki-kafka
 mvn clean install
 cd ..
+```
+
+#### graphql-jena
+```
 git clone https://github.com/National-Digital-Twin/graphql-jena
 cd graphql-jena
 mvn clean install -Dmaven.javadoc.skip=true
 cd ..
+```
+
+#### fuseki-yaml-config
+```
 git clone https://github.com/National-Digital-Twin/fuseki-yaml-config
-cd fuseki-yaml-config
-mvn clean install
+```
+
+> [!IMPORTANT]
+> Complete the steps outlined [here](https://github.com/National-Digital-Twin/fuseki-yaml-config/blob/main/INSTALLATION.md#1-build) under the **`1. Build:`** section and then return back to this guide and continue with the setup from this point onwards.
+
+```
 cd ..
+```
+
+#### secure-agent-graph
+```
 git clone https://github.com/National-Digital-Twin/secure-agent-graph.git
 cd secure-agent-graph
 mvn clean install

--- a/DeveloperDocumentation/Deployment/deployment-local.md
+++ b/DeveloperDocumentation/Deployment/deployment-local.md
@@ -80,7 +80,6 @@ cd ..
 git clone https://github.com/National-Digital-Twin/jwt-servlet-auth
 cd jwt-servlet-auth
 mvn clean install
-cd ..
 ```
 
 #### secure-agents-lib


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

During setting up of an IA node locally, the setup instructions for **`fuseki-yaml-config`** is missing some steps. In order to make things clearer, an instruction has been added to direct the person performing the setup to follow the actual setup steps for that particular repository before continuing with the local IA node deployment guide.

## Description

The documentation has been updated with clearer steps on setting up **`fuseki-yaml-config`** before continuing with the IA node local deployment guide.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
